### PR TITLE
Link to history page for changed pages.

### DIFF
--- a/templates/main/dashboard.html
+++ b/templates/main/dashboard.html
@@ -31,7 +31,7 @@
                     <div class="row">
                         <div class="span1 column"><a href="{{ user_profile.get_absolute_url }}"><img src="{% load gravatar %}{% gravatar_for_user history_item.user 50 %}" /></a></div>
                         <div class="span11 columns">
-                            <p><strong><a href="{{ user_profile.get_absolute_url }}">{{ history_item.user.username }}</a></strong> {{ history_item.action }} {% if history_item.page %}<a href="{{ history_item.page.get_absolute_url }}">{{ history_item.page }}</a>{% else %} <a href="{{ history_item.course.get_absolute_url }}">{{ history_item.course }}</a>{% endif %} <span title="{{ history_item.timestamp }}">{{ history_item.get_timesince }} ago</span></p>
+                            <p><strong><a href="{{ user_profile.get_absolute_url }}">{{ history_item.user.username }}</a></strong> {{ history_item.action }} {% if history_item.page %}<a href="{{ history_item.page.get_absolute_url + "/history" }}">{{ history_item.page }}</a>{% else %} <a href="{{ history_item.course.get_absolute_url }}">{{ history_item.course }}</a>{% endif %} <span title="{{ history_item.timestamp }}">{{ history_item.get_timesince }} ago</span></p>
                             {% if history_item.message %}<p>{{ history_item.message }}</p>{% endif %}
                         </div>
                     </div>

--- a/templates/pages/history.html
+++ b/templates/pages/history.html
@@ -28,7 +28,7 @@
             </thead>
             <tbody>
             {% for commit in commit_history %}
-                <tr>
+                <tr id= "{%commit.hexsha %}">
                     <td>{% gravatar_img_for_user commit.author.name 20 %} <a href="{% url "main_profile" commit.author.name %}">{{ commit.author.name }}</a></td>
                     <td>{{ commit.message|escape }}</td>
                     <td>{{ commit.date|date:"D, j M, Y H:i" }}</td>


### PR DESCRIPTION
When viewing the dashboard it seems more logical to linked to the actual changes on the page, allowing for a quicker view of what was actually changed.
