### PR TITLE
Fix section edit not working

### DIFF
--- a/assets/js/sectionedit.js
+++ b/assets/js/sectionedit.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
         // Get the name of the anchor for this header
         anchor = header.children[1].name;
         // Append an element
-        editLink = '<a href="' + baseURL + '/edit?section=' + anchor + '" class="editlink">edit</a>';
+        editLink = '<a href="' + baseURL + 'edit?section=' + anchor + '" class="editlink">edit</a>';
         $(header).append(editLink);
     }
 });


### PR DESCRIPTION
Looks like section edit was broken after enforcing trailing slash on the url? This trivial patch should fix it.

PTAL @dellsystem
